### PR TITLE
Allow tox tests to run in parallel + change docker-compose stuff + readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM python:3.5
-WORKDIR /workspace
-
-COPY dev-requirements.txt dev-requirements.txt
-RUN pip3 install -r dev-requirements.txt
-RUN pip3 install mypy-lang
-COPY . .
-
-CMD ["/workspace/run_tests.sh"]

--- a/README.md
+++ b/README.md
@@ -85,9 +85,18 @@ server can be very easily brought up with docker, so there is no reason to use
 mocking most of the time, the tests should run directly against a real minio
 instance.
 
-To run the tests, you need docker and docker compose, then it is as simple as:
+To run the tests you need to have minio running locally with some specific
+settings, you can start it using docker-compose:
 
-    docker-compose run django ./run_tests.sh
+    docker-compose up -d
+
+Use tox to run the tests for all environments in tox.ini:
+
+    tox
+
+Or just run tests for some of them
+
+    tox -e py35-django110,py35-django111
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,10 @@
 version: "2"
 services:
-    django:
-        build: .
-        volumes:
-            - ".:/workspace"
-        depends_on:
-            - minio
-        environment:
-            MINIO_STORAGE_ACCESS_KEY: key2000
-            MINIO_STORAGE_SECRET_KEY: secret2000
     minio:
         image: "minio/minio"
         command: server /export
         environment:
-            MINIO_ACCESS_KEY: key2000
-            MINIO_SECRET_KEY: secret2000
+            MINIO_ACCESS_KEY: weak_access_key
+            MINIO_SECRET_KEY: weak_secret_key
         ports:
             - "9000:9000"

--- a/tests/django_minio_storage_tests/settings.py
+++ b/tests/django_minio_storage_tests/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 
 import os
 
+from tests.test_app.tests.utils import bucket_name
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -34,10 +36,10 @@ STATICFILES_STORAGE = "minio_storage.storage.MinioStaticStorage"
 MINIO_STORAGE_ENDPOINT = os.getenv("MINIO_STORAGE_ENDPOINT", "minio:9000")
 MINIO_STORAGE_ACCESS_KEY = os.environ["MINIO_STORAGE_ACCESS_KEY"]
 MINIO_STORAGE_SECRET_KEY = os.environ["MINIO_STORAGE_SECRET_KEY"]
-MINIO_STORAGE_MEDIA_BUCKET_NAME = "tests-media"
+MINIO_STORAGE_MEDIA_BUCKET_NAME = bucket_name("tests-media")
 MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET = True
 MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET = True
-MINIO_STORAGE_STATIC_BUCKET_NAME = "tests-static"
+MINIO_STORAGE_STATIC_BUCKET_NAME = bucket_name("tests-static")
 MINIO_STORAGE_USE_HTTPS = False
 
 MINIO_PARTIAL_URL = True

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ setenv =
         MINIO_STORAGE_ENDPOINT=localhost:9000
         MINIO_STORAGE_ACCESS_KEY=weak_access_key
         MINIO_STORAGE_SECRET_KEY=weak_secret_key
+        TOX_ENVNAME={envname}
 deps =
         django18: Django>=1.8,<1.9
         django19: Django>=1.9,<1.10


### PR DESCRIPTION
**ready for merge**


Detox can now be used to run local tests in parallel. This pull request also
fixes documentation and removes some docker stuff which didn't work properly
and looked a bit out of place.