### PR TITLE
Download file content to allow for seeking

### DIFF
--- a/tests/test_app/tests/upload_tests.py
+++ b/tests/test_app/tests/upload_tests.py
@@ -52,6 +52,14 @@ class UploadTests(BaseTestMixin, TestCase):
         with self.assertRaises(NotImplementedError):
             self.media_storage.open(test_file, mode="bw")
 
+    def test_files_seekable(self):
+        self.media_storage.save("read_seek_test.txt",
+                                ContentFile(b"should not change"))
+
+        f = self.media_storage.open("read_seek_test.txt", mode="br")
+        f.seek(4)
+        f.seek(0)
+
     def test_upload_and_get_back_file_with_funky_name(self):
         self.media_storage.save("áčďěščřžýŽŇůúť.txt", ContentFile(b"12345"))
 


### PR DESCRIPTION
**ready to merge**

Related to #16 

While it is possible to implement a custom reader type which uses
`get_partial_object()` to implement a reader with`seek()` it's probably a
narrow use case enough that it can be put aside for now. 

- [x] Add a test which uses seek on a returned file.

- [x] Use a verified efficient buffered method to copy into the local spooled
  file, I just tookthe code which was in the minio-py example now. *Now using
  the same buffer size as minio-py's fgetf*

- [X] Handle errors properly *Looks ok*

- [X] ~If spooled temporary file is to be used the maximum in memory size
  should be configurable (by subclassing the MinioStorage class into a django
  project)~ **Postponing to a general configurability review later on**


- [X] ~Come up with a suitable solution for re-enabling direct streaming.. One
  solution is to have the possibility to disable it by subclassing (can be
  provided in 'django-minio-storage''s storage.py module).. The end user has to
  be made aware of possible implications.~ **Postponing to a general
  configurability review later on**