### PR TITLE
Make open method raise only IOError exception. Bump minio-py version to 2.2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     setup_requires=['setuptools_scm'],
     install_requires=[
         "django>=1.8",
-        "minio>=2.2.3",
+        "minio>=2.2.4",
     ],
     extras_require={
         "test": [

--- a/tests/test_app/tests/retrieve_tests.py
+++ b/tests/test_app/tests/retrieve_tests.py
@@ -7,7 +7,6 @@ import io
 import requests
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
-from minio.error import NoSuchKey
 from minio.policy import Policy
 
 from minio_storage.storage import MinioMediaStorage, MinioStaticStorage
@@ -88,7 +87,7 @@ class RetrieveTestsWithRestrictedBucket(BaseTestMixin, TestCase):
         self.assertFalse(self.media_storage.exists("nonexistent.txt"))
 
     def test_opening_non_existing_file_raises_exception(self):
-        with self.assertRaises(NoSuchKey):
+        with self.assertRaises(IOError):
             self.media_storage.open("this does not exist")
 
     def test_file_names_are_properly_sanitized(self):

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
         django110: Django>=1.10,<1.11
         django111: Django>=1.11,<2.0
         minio: minio
-        minio223: minio==2.2.3
+        minio22X: minio==2.2.4
         -rdev-requirements.txt
 
 [testenv:isort]
@@ -59,8 +59,8 @@ commands = mkdocs build
 
 [tox]
 envlist =
-       {py27,py34,py35}-django{18,19,110,111}-minio223,
-       py36-django111-minio{,223},
+       {py27,py34,py35}-django{18,19,110,111}-minio22X,
+       py36-django111-minio{,22X},
        lint,
        isort,
        docs,


### PR DESCRIPTION
Make open method throw only IOError exception. 
Bump minio-py version to 2.2.4