### PR TITLE
Fix windows path compatibility

### DIFF
--- a/tests/test_app/tests/upload_tests.py
+++ b/tests/test_app/tests/upload_tests.py
@@ -82,3 +82,10 @@ class UploadTests(BaseTestMixin, TestCase):
 
     def test_static_files_end_up_in_the_right_bucket(self):
         pass
+
+    def test_upload_file_beggining_with_dot(self):
+        self.media_storage.save(".hidden_file",
+                                ContentFile(b"Not really, but whatever"))
+        self.assertTrue(self.media_storage.exists('.hidden_file'))
+        self.media_storage.delete(".hidden_file")
+        self.assertFalse(self.media_storage.exists('.hidden_file'))


### PR DESCRIPTION
Taken from django-storages s3 implementation:
```py
 def _clean_name(self, name):
        """
        Cleans the name so that Windows style paths work
        """
        # Normalize Windows style paths
        clean_name = posixpath.normpath(name).replace('\\', '/')

        # os.path.normpath() can strip trailing slashes so we implement
        # a workaround here.
        if name.endswith('/') and not clean_name.endswith('/'):
            # Add a trailing slash as it was stripped.
            clean_name += '/'
        return clean_name
```