### PR TITLE
Fixed issue with `MinioStorage._sanitize_path`

### DIFF
--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -69,7 +69,9 @@ class MinioStorage(Storage):
         super(MinioStorage, self).__init__()
 
     def _sanitize_path(self, name):
-        return name.lstrip("./")
+        if name.startswith('./'):
+            return name[2:]
+        return name
 
     def _examine_file(self, name, content):
         """Examines a file and produces information necessary for upload.

--- a/tests/test_app/tests/upload_tests.py
+++ b/tests/test_app/tests/upload_tests.py
@@ -82,3 +82,10 @@ class UploadTests(BaseTestMixin, TestCase):
 
     def test_static_files_end_up_in_the_right_bucket(self):
         pass
+
+    def test_upload_file_beggining_with_dot(self):
+        self.media_storage.save(".hidden_file",
+                                ContentFile(b"Not really, but whatever"))
+        self.assertTrue(self.media_storage.exists('.hidden_file'))
+        self.media_storage.delete(".hidden_file")
+        self.assertFalse(self.media_storage.exists('.hidden_file'))


### PR DESCRIPTION
Calling `".foo.bar".lstrip("./")` results in `foo.bar` instead of `.foo.bar`

Since the idea is to remove `./` from the beginning of the object name, I changed the `_sanitize_path` method to do that using `startswith` and slicing the string

Fixes #3 