### PR TITLE
Added "safe delete" feature

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,22 +61,22 @@ The following settings are available:
   calculated signature so be careful with how `MINIO_STORAGE_STATIC_URL` is
   used, normally it should not have to be set at all.
 
-- `MINIO_STORAGE_SAFE_DELETE`: If set to `True`, any call to `.delete()` will
-  cause the storage to make a copy of the file somewhere else before actually
-  deleting it (default: `False`).
+- `MINIO_STORAGE_BACKUP_ON_DELETE`: If set to `True`, any call to `.delete()`
+  will cause the storage to make a copy of the file somewhere else before
+  actually deleting it (default: `False`).
 
-- `MINIO_STORAGE_SAFE_DELETE_BUCKET`: Bucket to be used to store deleted files.
+- `MINIO_STORAGE_BACKUP_ON_BUCKET`: Bucket to be used to store deleted files.
   The bucket **has to exists**, the storage will not try to create it.
-  Required if `MINIO_STORAGE_SAFE_DELETE` is `True`.
+  Required if `MINIO_STORAGE_BACKUP_ON_DELETE` is `True`.
 
-- `MINIO_STORAGE_SAFE_DELETE_PATH`: Path to be used to store deleted files,
+- `MINIO_STORAGE_BACKUP_ON_PATH`: Path to be used to store deleted files,
   the path can contain Python's `strftime` substitutes, such as `%H`, `%c` and
   others. The object name will be appended to the resulting path, without
   actually forcing another `/` at the end, so if you set this setting to
   `backup-%Y-%m_` then the resulting object name will be (e.g.)
   `backup-2018-07_my_object.data`. If you want to store the objects inside
   folders, make sure to finish this setting with a forward slash.
-  Required if `MINIO_STORAGE_SAFE_DELETE` is `True`.
+  Required if `MINIO_STORAGE_BACKUP_ON_DELETE` is `True`.
 
 - `MINIO_STORAGE_MEDIA_USE_PRESIGNED`: Determines if the media file URLs should
   be pre-signed (default: `False`)
@@ -100,9 +100,9 @@ MINIO_STORAGE_MEDIA_BUCKET_NAME = 'local-media'
 MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET = True
 MINIO_STORAGE_STATIC_BUCKET_NAME = 'local-static'
 MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET = True
-MINIO_STORAGE_SAFE_DELETE = True
-MINIO_STORAGE_SAFE_DELETE_BUCKET = 'Recycle Bin'
-MINIO_STORAGE_SAFE_DELETE_PATH = '%c/'
+MINIO_STORAGE_BACKUP_ON_DELETE = True
+MINIO_STORAGE_BACKUP_ON_BUCKET = 'Recycle Bin'
+MINIO_STORAGE_BACKUP_ON_PATH = '%c/'
 
 # These settings should generally not be used:
 # MINIO_STORAGE_MEDIA_URL = 'http://localhost:9000/local-media'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,7 +61,7 @@ The following settings are available:
   calculated signature so be careful with how `MINIO_STORAGE_STATIC_URL` is
   used, normally it should not have to be set at all.
 
-- `MINIO_STORAGE_MEDIA_BUCKET_NAME`: Bucket to be used to store deleted files.
+- `MINIO_STORAGE_MEDIA_BACKUP_BUCKET`: Bucket to be used to store deleted files.
   The bucket **has to exists**, the storage will not try to create it.
   Required if `MINIO_STORAGE_MEDIA_BACKUP_FORMAT` is set.
 
@@ -72,7 +72,7 @@ The following settings are available:
   `backup-%Y-%m_` then the resulting object name will be (e.g.)
   `backup-2018-07_my_object.data`. If you want to store the objects inside
   folders, make sure to finish this setting with a forward slash.
-  Required if `MINIO_STORAGE_MEDIA_BUCKET_NAME` is set.
+  Required if `MINIO_STORAGE_MEDIA_BACKUP_BUCKET` is set.
 
 - `MINIO_STORAGE_MEDIA_USE_PRESIGNED`: Determines if the media file URLs should
   be pre-signed (default: `False`)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,22 +61,18 @@ The following settings are available:
   calculated signature so be careful with how `MINIO_STORAGE_STATIC_URL` is
   used, normally it should not have to be set at all.
 
-- `MINIO_STORAGE_BACKUP_ON_DELETE`: If set to `True`, any call to `.delete()`
-  will cause the storage to make a copy of the file somewhere else before
-  actually deleting it (default: `False`).
-
-- `MINIO_STORAGE_BACKUP_ON_BUCKET`: Bucket to be used to store deleted files.
+- `MINIO_STORAGE_MEDIA_BUCKET_NAME`: Bucket to be used to store deleted files.
   The bucket **has to exists**, the storage will not try to create it.
-  Required if `MINIO_STORAGE_BACKUP_ON_DELETE` is `True`.
+  Required if `MINIO_STORAGE_MEDIA_BACKUP_FORMAT` is set.
 
-- `MINIO_STORAGE_BACKUP_ON_PATH`: Path to be used to store deleted files,
+- `MINIO_STORAGE_MEDIA_BACKUP_FORMAT`: Path to be used to store deleted files,
   the path can contain Python's `strftime` substitutes, such as `%H`, `%c` and
   others. The object name will be appended to the resulting path, without
   actually forcing another `/` at the end, so if you set this setting to
   `backup-%Y-%m_` then the resulting object name will be (e.g.)
   `backup-2018-07_my_object.data`. If you want to store the objects inside
   folders, make sure to finish this setting with a forward slash.
-  Required if `MINIO_STORAGE_BACKUP_ON_DELETE` is `True`.
+  Required if `MINIO_STORAGE_MEDIA_BUCKET_NAME` is set.
 
 - `MINIO_STORAGE_MEDIA_USE_PRESIGNED`: Determines if the media file URLs should
   be pre-signed (default: `False`)
@@ -97,12 +93,11 @@ MINIO_STORAGE_ACCESS_KEY = 'KBP6WXGPS387090EZMG8'
 MINIO_STORAGE_SECRET_KEY = 'DRjFXylyfMqn2zilAr33xORhaYz5r9e8r37XPz3A'
 MINIO_STORAGE_USE_HTTPS = False
 MINIO_STORAGE_MEDIA_BUCKET_NAME = 'local-media'
+MINIO_STORAGE_MEDIA_BACKUP_BUCKET = 'Recycle Bin'
+MINIO_STORAGE_MEDIA_BACKUP_FORMAT = '%c/'
 MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET = True
 MINIO_STORAGE_STATIC_BUCKET_NAME = 'local-static'
 MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET = True
-MINIO_STORAGE_BACKUP_ON_DELETE = True
-MINIO_STORAGE_BACKUP_ON_BUCKET = 'Recycle Bin'
-MINIO_STORAGE_BACKUP_ON_PATH = '%c/'
 
 # These settings should generally not be used:
 # MINIO_STORAGE_MEDIA_URL = 'http://localhost:9000/local-media'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,23 @@ The following settings are available:
   calculated signature so be careful with how `MINIO_STORAGE_STATIC_URL` is
   used, normally it should not have to be set at all.
 
+- `MINIO_STORAGE_SAFE_DELETE`: If set to `True`, any call to `.delete()` will
+  cause the storage to make a copy of the file somewhere else before actually
+  deleting it (default: `False`).
+
+- `MINIO_STORAGE_SAFE_DELETE_BUCKET`: Bucket to be used to store deleted files.
+  The bucket **has to exists**, the storage will not try to create it.
+  Required if `MINIO_STORAGE_SAFE_DELETE` is `True`.
+
+- `MINIO_STORAGE_SAFE_DELETE_PATH`: Path to be used to store deleted files,
+  the path can contain Python's `strftime` substitutes, such as `%H`, `%c` and
+  others. The object name will be appended to the resulting path, without
+  actually forcing another `/` at the end, so if you set this setting to
+  `backup-%Y-%m_` then the resulting object name will be (e.g.)
+  `backup-2018-07_my_object.data`. If you want to store the objects inside
+  folders, make sure to finish this setting with a forward slash.
+  Required if `MINIO_STORAGE_SAFE_DELETE` is `True`.
+
 - `MINIO_STORAGE_MEDIA_USE_PRESIGNED`: Determines if the media file URLs should
   be pre-signed (default: `False`)
 
@@ -83,6 +100,9 @@ MINIO_STORAGE_MEDIA_BUCKET_NAME = 'local-media'
 MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET = True
 MINIO_STORAGE_STATIC_BUCKET_NAME = 'local-static'
 MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET = True
+MINIO_STORAGE_SAFE_DELETE = True
+MINIO_STORAGE_SAFE_DELETE_BUCKET = 'Recycle Bin'
+MINIO_STORAGE_SAFE_DELETE_PATH = '%c/'
 
 # These settings should generally not be used:
 # MINIO_STORAGE_MEDIA_URL = 'http://localhost:9000/local-media'

--- a/tests/test_app/tests/delete_tests.py
+++ b/tests/test_app/tests/delete_tests.py
@@ -1,8 +1,10 @@
 # encoding: utf-8
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.core.files.base import ContentFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from .utils import BaseTestMixin
 
@@ -13,4 +15,20 @@ class DeleteTests(BaseTestMixin, TestCase):
         test_file = self.media_storage.save("should_be_removed.txt",
                                             ContentFile(b"meh"))
         self.media_storage.delete(test_file)
+        self.assertFalse(self.media_storage.exists(test_file))
+
+
+@override_settings(MINIO_STORAGE_SAFE_DELETE=True)
+@override_settings(
+    MINIO_STORAGE_SAFE_DELETE_BUCKET=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME)
+@override_settings(MINIO_STORAGE_SAFE_DELETE_PATH='Recycle Bin/%Y-%m-%d/')
+class SafeDeleteTests(BaseTestMixin, TestCase):
+    def test_safe_file_removal(self):
+        test_file = self.media_storage.save("should_be_removed.txt",
+                                            ContentFile(b"meh"))
+        self.media_storage.delete(test_file)
+        now = timezone.now()
+        removed_filename = now.strftime(
+            'Recycle Bin/%Y-%m-%d/should_be_removed.txt')
+        self.assertTrue(self.media_storage.exists(removed_filename))
         self.assertFalse(self.media_storage.exists(test_file))

--- a/tests/test_app/tests/delete_tests.py
+++ b/tests/test_app/tests/delete_tests.py
@@ -18,12 +18,12 @@ class DeleteTests(BaseTestMixin, TestCase):
         self.assertFalse(self.media_storage.exists(test_file))
 
 
-@override_settings(MINIO_STORAGE_SAFE_DELETE=True)
+@override_settings(MINIO_STORAGE_BACKUP_ON_DELETE=True)
 @override_settings(
-    MINIO_STORAGE_SAFE_DELETE_BUCKET=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME)
-@override_settings(MINIO_STORAGE_SAFE_DELETE_PATH='Recycle Bin/%Y-%m-%d/')
+    MINIO_STORAGE_BACKUP_ON_BUCKET=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME)
+@override_settings(MINIO_STORAGE_BACKUP_ON_PATH='Recycle Bin/%Y-%m-%d/')
 class SafeDeleteTests(BaseTestMixin, TestCase):
-    def test_safe_file_removal(self):
+    def test_backup_on_file_removal(self):
         test_file = self.media_storage.save("should_be_removed.txt",
                                             ContentFile(b"meh"))
         self.media_storage.delete(test_file)

--- a/tests/test_app/tests/delete_tests.py
+++ b/tests/test_app/tests/delete_tests.py
@@ -18,11 +18,10 @@ class DeleteTests(BaseTestMixin, TestCase):
         self.assertFalse(self.media_storage.exists(test_file))
 
 
-@override_settings(MINIO_STORAGE_BACKUP_ON_DELETE=True)
 @override_settings(
-    MINIO_STORAGE_BACKUP_ON_BUCKET=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME)
-@override_settings(MINIO_STORAGE_BACKUP_ON_PATH='Recycle Bin/%Y-%m-%d/')
-class SafeDeleteTests(BaseTestMixin, TestCase):
+    MINIO_STORAGE_MEDIA_BACKUP_BUCKET=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME)
+@override_settings(MINIO_STORAGE_MEDIA_BACKUP_FORMAT='Recycle Bin/%Y-%m-%d/')
+class BackupOnDeleteTests(BaseTestMixin, TestCase):
     def test_backup_on_file_removal(self):
         test_file = self.media_storage.save("should_be_removed.txt",
                                             ContentFile(b"meh"))
@@ -32,3 +31,13 @@ class SafeDeleteTests(BaseTestMixin, TestCase):
             'Recycle Bin/%Y-%m-%d/should_be_removed.txt')
         self.assertTrue(self.media_storage.exists(removed_filename))
         self.assertFalse(self.media_storage.exists(test_file))
+
+    def test_no_backups_for_static_files_by_default(self):
+        test_file = self.static_storage.save("should_be_removed.txt",
+                                             ContentFile(b"meh"))
+        self.static_storage.delete(test_file)
+        now = timezone.now()
+        removed_filename = now.strftime(
+            'Recycle Bin/%Y-%m-%d/should_be_removed.txt')
+        self.assertFalse(self.static_storage.exists(removed_filename))
+        self.assertFalse(self.static_storage.exists(test_file))

--- a/tests/test_app/tests/utils.py
+++ b/tests/test_app/tests/utils.py
@@ -52,7 +52,7 @@ class BaseTestMixin:
         client = self.minio_client()
 
         def obliterate_bucket(name):
-            for obj in client.list_objects(name, ""):
+            for obj in client.list_objects(name, "", True):
                 client.remove_object(name, obj.object_name)
             for obj in client.list_incomplete_uploads(name, ""):  # pragma: no cover  # noqa
                 client.remove_incomplete_upload(name, obj.objectname)


### PR DESCRIPTION
When enabled, calling `.delete()` on a file will cause it to be moved
somewhere else to be retrieved back if necessary.

It is possible to use `strftime` formatting on the backup object name

Cleaning up the backup folder is not included

This feature came up so we could fulfill contract requirements with backup clauses. With this feature we can backup minio using `mc mirror --remove minio/ /backup/folder/` and still delete files normally.