### PR TITLE
feature/ignore-buckets-checks

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,10 @@ The following settings are available:
 - `MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET`: whether to create the bucket if it
   does not already exist (default: `False`)
 
+- `MINIO_STORAGE_ASSUME_MEDIA_BUCKET_EXISTS`: whether to ignore media bucket 
+  creation and policy.  
+  (default: `False`)
+
 - `MINIO_STORAGE_AUTO_CREATE_MEDIA_POLICY`: sets the buckets public policy
   right after it's been created by `MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET`.
   Valid values are: `GET_ONLY`, `READ_ONLY`, `WRITE_ONLY`, `READ_WRITE` and
@@ -39,6 +43,11 @@ The following settings are available:
 
 - `MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET`: whether to create the bucket if it
   does not already exist (default: `False`)
+
+
+- `MINIO_STORAGE_ASSUME_STATIC_BUCKET_EXISTS`: whether to ignore the static bucket 
+  creation and policy.  
+  (default: `False`)
 
 - `MINIO_STORAGE_AUTO_CREATE_STATIC_POLICY`: sets the buckets public policy
   right after it's been created by `MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET`.

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -46,6 +46,7 @@ class MinioStorage(Storage):
         policy_type: T.Optional[Policy] = None,
         backup_format: T.Optional[str] = None,
         backup_bucket: T.Optional[str] = None,
+        assume_bucket_exists: bool = False,
         **kwargs,
     ):
         self.client = minio_client
@@ -64,6 +65,7 @@ class MinioStorage(Storage):
             self.file_class = file_class
         self.auto_create_bucket = auto_create_bucket
         self.auto_create_policy = auto_create_policy
+        self.assume_bucket_exists = assume_bucket_exists
         self.policy_type = policy_type
 
         self.presign_urls = presign_urls
@@ -73,18 +75,21 @@ class MinioStorage(Storage):
         super().__init__()
 
     def _init_check(self):
-        if self.auto_create_bucket and not self.client.bucket_exists(self.bucket_name):
-            self.client.make_bucket(self.bucket_name)
-            if self.auto_create_policy:
-                policy_type = self.policy_type
-                if policy_type is None:
-                    policy_type = Policy.get
-                self.client.set_bucket_policy(
-                    self.bucket_name, policy_type.bucket(self.bucket_name)
-                )
+        if not self.assume_bucket_exists:
+            if self.auto_create_bucket and not self.client.bucket_exists(
+                self.bucket_name
+            ):
+                self.client.make_bucket(self.bucket_name)
+                if self.auto_create_policy:
+                    policy_type = self.policy_type
+                    if policy_type is None:
+                        policy_type = Policy.get
+                    self.client.set_bucket_policy(
+                        self.bucket_name, policy_type.bucket(self.bucket_name)
+                    )
 
-        elif not self.client.bucket_exists(self.bucket_name):
-            raise OSError(f"The bucket {self.bucket_name} does not exist")
+            elif not self.client.bucket_exists(self.bucket_name):
+                raise OSError(f"The bucket {self.bucket_name} does not exist")
 
     def _sanitize_path(self, name):
         v = posixpath.normpath(name).replace("\\", "/")
@@ -337,6 +342,10 @@ class MinioMediaStorage(MinioStorage):
         backup_format = get_setting("MINIO_STORAGE_MEDIA_BACKUP_FORMAT", False)
         backup_bucket = get_setting("MINIO_STORAGE_MEDIA_BACKUP_BUCKET", False)
 
+        assume_bucket_exists = get_setting(
+            "MINIO_STORAGE_ASSUME_MEDIA_BUCKET_EXISTS", False
+        )
+
         super().__init__(
             client,
             bucket_name,
@@ -347,6 +356,7 @@ class MinioMediaStorage(MinioStorage):
             presign_urls=presign_urls,
             backup_format=backup_format,
             backup_bucket=backup_bucket,
+            assume_bucket_exists=assume_bucket_exists,
         )
 
 
@@ -370,6 +380,10 @@ class MinioStaticStorage(MinioStorage):
 
         presign_urls = get_setting("MINIO_STORAGE_STATIC_USE_PRESIGNED", False)
 
+        assume_bucket_exists = get_setting(
+            "MINIO_STORAGE_ASSUME_STATIC_BUCKET_EXISTS", False
+        )
+
         super().__init__(
             client,
             bucket_name,
@@ -378,4 +392,5 @@ class MinioStaticStorage(MinioStorage):
             policy_type=policy_type,
             base_url=base_url,
             presign_urls=presign_urls,
+            assume_bucket_exists=assume_bucket_exists,
         )

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -46,6 +46,7 @@ class MinioStorage(Storage):
         policy_type: T.Optional[Policy] = None,
         backup_format: T.Optional[str] = None,
         backup_bucket: T.Optional[str] = None,
+        ignore_bucket_check: bool = False,
         **kwargs,
     ):
         self.client = minio_client
@@ -68,7 +69,8 @@ class MinioStorage(Storage):
 
         self.presign_urls = presign_urls
 
-        self._init_check()
+        if not ignore_bucket_check:
+            self._init_check()
 
         super().__init__()
 
@@ -337,6 +339,10 @@ class MinioMediaStorage(MinioStorage):
         backup_format = get_setting("MINIO_STORAGE_MEDIA_BACKUP_FORMAT", False)
         backup_bucket = get_setting("MINIO_STORAGE_MEDIA_BACKUP_BUCKET", False)
 
+        ignore_bucket_check = get_setting(
+            "MINIO_STORAGE_MEDIA_IGNORE_BUCKET_CHECK", False
+        )
+
         super().__init__(
             client,
             bucket_name,
@@ -347,6 +353,7 @@ class MinioMediaStorage(MinioStorage):
             presign_urls=presign_urls,
             backup_format=backup_format,
             backup_bucket=backup_bucket,
+            ignore_bucket_check=ignore_bucket_check,
         )
 
 
@@ -370,6 +377,10 @@ class MinioStaticStorage(MinioStorage):
 
         presign_urls = get_setting("MINIO_STORAGE_STATIC_USE_PRESIGNED", False)
 
+        ignore_bucket_check = get_setting(
+            "MINIO_STORAGE_STATIC_IGNORE_BUCKET_CHECK", False
+        )
+
         super().__init__(
             client,
             bucket_name,
@@ -378,4 +389,5 @@ class MinioStaticStorage(MinioStorage):
             policy_type=policy_type,
             base_url=base_url,
             presign_urls=presign_urls,
+            ignore_bucket_check=ignore_bucket_check,
         )

--- a/tests/test_app/tests/bucket_tests.py
+++ b/tests/test_app/tests/bucket_tests.py
@@ -33,6 +33,32 @@ class BucketTests(BaseTestMixin, TestCase):
         with self.assertRaises(ImproperlyConfigured):
             get_setting("INEXISTENT_SETTING")
 
+    @override_settings(
+        MINIO_STORAGE_MEDIA_BUCKET_NAME="inexistent",
+        MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET=False,
+        MINIO_STORAGE_ASSUME_MEDIA_BUCKET_EXISTS=True,
+    )
+    def test_media_storage_ignore_bucket_check(self):
+        try:
+            MinioMediaStorage()
+        except OSError:
+            self.assertTrue(False)
+        else:
+            pass
+
+    @override_settings(
+        MINIO_STORAGE_STATIC_BUCKET_NAME="inexistent",
+        MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET=False,
+        MINIO_STORAGE_ASSUME_STATIC_BUCKET_EXISTS=True,
+    )
+    def test_static_storage_ignore_bucket_check(self):
+        try:
+            MinioStaticStorage()
+        except OSError:
+            self.assertTrue(False)
+        else:
+            pass
+
 
 class BucketPolicyTests(BaseTestMixin, TestCase):
     def setUp(self):

--- a/tests/test_app/tests/bucket_tests.py
+++ b/tests/test_app/tests/bucket_tests.py
@@ -33,6 +33,32 @@ class BucketTests(BaseTestMixin, TestCase):
         with self.assertRaises(ImproperlyConfigured):
             get_setting("INEXISTENT_SETTING")
 
+    @override_settings(
+        MINIO_STORAGE_MEDIA_BUCKET_NAME="inexistent",
+        MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET=False,
+        MINIO_STORAGE_MEDIA_IGNORE_BUCKET_CHECK=True,
+    )
+    def test_media_storage_ignore_bucket_check(self):
+        try:
+            MinioMediaStorage()
+        except:
+            self.assertTrue(False)
+        else:
+            pass
+
+    @override_settings(
+        MINIO_STORAGE_STATIC_BUCKET_NAME="inexistent",
+        MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET=False,
+        MINIO_STORAGE_STATIC_IGNORE_BUCKET_CHECK=True,
+    )
+    def test_static_storage_ignore_bucket_check(self):
+        try:
+            MinioStaticStorage()
+        except:
+            self.assertTrue(False)
+        else:
+            pass
+
 
 class BucketPolicyTests(BaseTestMixin, TestCase):
     def setUp(self):

--- a/tests/test_app/tests/bucket_tests.py
+++ b/tests/test_app/tests/bucket_tests.py
@@ -36,7 +36,7 @@ class BucketTests(BaseTestMixin, TestCase):
     @override_settings(
         MINIO_STORAGE_MEDIA_BUCKET_NAME="inexistent",
         MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET=False,
-        MINIO_STORAGE_MEDIA_IGNORE_BUCKET_CHECK=True,
+        MINIO_STORAGE_ASSUME_MEDIA_BUCKET_EXISTS=True,
     )
     def test_media_storage_ignore_bucket_check(self):
         try:
@@ -49,7 +49,7 @@ class BucketTests(BaseTestMixin, TestCase):
     @override_settings(
         MINIO_STORAGE_STATIC_BUCKET_NAME="inexistent",
         MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET=False,
-        MINIO_STORAGE_STATIC_IGNORE_BUCKET_CHECK=True,
+        MINIO_STORAGE_ASSUME_STATIC_BUCKET_EXISTS=True,
     )
     def test_static_storage_ignore_bucket_check(self):
         try:

--- a/tests/test_app/tests/bucket_tests.py
+++ b/tests/test_app/tests/bucket_tests.py
@@ -41,7 +41,7 @@ class BucketTests(BaseTestMixin, TestCase):
     def test_media_storage_ignore_bucket_check(self):
         try:
             MinioMediaStorage()
-        except:
+        except OSError:
             self.assertTrue(False)
         else:
             pass
@@ -54,7 +54,7 @@ class BucketTests(BaseTestMixin, TestCase):
     def test_static_storage_ignore_bucket_check(self):
         try:
             MinioStaticStorage()
-        except:
+        except OSError:
             self.assertTrue(False)
         else:
             pass

--- a/tests/test_app/tests/bucket_tests.py
+++ b/tests/test_app/tests/bucket_tests.py
@@ -33,6 +33,34 @@ class BucketTests(BaseTestMixin, TestCase):
         with self.assertRaises(ImproperlyConfigured):
             get_setting("INEXISTENT_SETTING")
 
+    @override_settings(
+        MINIO_STORAGE_MEDIA_BUCKET_NAME="inexistent",
+        MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET=False,
+        MINIO_STORAGE_MEDIA_IGNORE_BUCKET_CHECK=True,
+
+    )
+    def test_media_storage_ignore_bucket_check(self):
+        try:
+            MinioMediaStorage()
+        except:
+            self.assertTrue(False)
+        else:
+            pass
+
+    @override_settings(
+        MINIO_STORAGE_STATIC_BUCKET_NAME="inexistent",
+        MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET=False,
+        MINIO_STORAGE_STATIC_IGNORE_BUCKET_CHECK=True,
+
+    )
+    def test_static_storage_ignore_bucket_check(self):
+        try:
+            MinioStaticStorage()
+        except:
+            self.assertTrue(False)
+        else:
+            pass
+
 
 class BucketPolicyTests(BaseTestMixin, TestCase):
     def setUp(self):


### PR DESCRIPTION
When running minio as a GCS gateway, testing bucket existancy take too much time (25ms instead of 1 ms when running minio in FS mode).

I've add some settings to disable the bucket check in _init_check, assuming the bucket exists with right policy.