### PR TITLE
Remove use of deprecated django.conf.urls.url

### DIFF
--- a/tests/django_minio_storage_tests/urls.py
+++ b/tests/django_minio_storage_tests/urls.py
@@ -13,7 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path
 
-urlpatterns = [url(r"^admin/", admin.site.urls)]
+urlpatterns = [path("admin/", admin.site.urls)]


### PR DESCRIPTION
This was deprecated in Django 3.1.

See: https://docs.djangoproject.com/en/3.1/releases/3.1/#id2