### PR TITLE
Let user specify a HTTP proxy and region

### DIFF
--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -3,6 +3,7 @@ import mimetypes
 import posixpath
 import typing as T
 import urllib
+import urllib3
 from logging import getLogger
 from time import mktime
 from urllib.parse import urlsplit, urlunsplit
@@ -365,6 +366,20 @@ def create_minio_client_from_settings(*, minio_kwargs=dict()):
     access_key = get_setting("MINIO_STORAGE_ACCESS_KEY")
     secret_key = get_setting("MINIO_STORAGE_SECRET_KEY")
     secure = get_setting("MINIO_STORAGE_USE_HTTPS", True)
+    region = get_setting("MINIO_STORAGE_REGION", 'us-east-1')
+    # Eventually handle the need for a HTTP proxy
+    http_client = None
+    if get_setting("MINIO_STORAGE_HTTP_PROXY"):
+        http_client = urllib3.ProxyManager(
+            get_setting("MINIO_STORAGE_HTTP_PROXY"),
+            timeout=urllib3.Timeout.DEFAULT_TIMEOUT,
+            retries=urllib3.Retry(
+                total=5,
+                backoff_factor=0.2,
+                status_forcelist=[500, 502, 503, 504],
+            )
+        )
+
     # Making this client deconstructible allows it to be passed directly as
     # an argument to MinioStorage, since Django needs to be able to
     # deconstruct all Storage constructor arguments for Storages referenced in
@@ -374,6 +389,8 @@ def create_minio_client_from_settings(*, minio_kwargs=dict()):
         access_key=access_key,
         secret_key=secret_key,
         secure=secure,
+        region=region,
+        http_client=http_client,
         **minio_kwargs,
     )
     return client


### PR DESCRIPTION
Hi,

In many corporate situations, an HTTP proxy is required to contact the object storage endpoint. This PR adds support for this situation, following the indications in https://docs.min.io/docs/python-client-api-reference.html (search for "corporate proxy" in the page).

Additionnally, when using another storage than AWS, the region parameter might differ and be required to be edited. This is typically the case for OVH Public Cloud services where region is to be set to an OVH region (sbg for instance).

Best,