### PR TITLE
add MINIO_STORAGE_REGION setting 

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,8 @@ The following settings are available:
   `minio.example.org:9000` (note that there is no scheme)).
 
 - `MINIO_STORAGE_ACCESS_KEY` and `MINIO_STORAGE_SECRET_KEY` (mandatory)
+  
+- `MINIO_STORAGE_REGION`: Allows you to specify the region. By setting this configuration option, an additional HTTP request to Minio for region checking can be prevented, resulting in improved performance and reduced latency for generating presigned URLs.
 
 - `MINIO_STORAGE_USE_HTTPS`: whether to use TLS or not (default: `True`). This
   affect both how how Django internally communicates with the Minio server AND

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -364,11 +364,17 @@ def get_setting(name: str, default=_NoValue) -> T.Any:
 
 
 def create_minio_client_from_settings(*, minio_kwargs=None):
-    minio_kwargs = minio_kwargs or {}
+    kwargs = {}
     endpoint = get_setting("MINIO_STORAGE_ENDPOINT")
     access_key = get_setting("MINIO_STORAGE_ACCESS_KEY")
     secret_key = get_setting("MINIO_STORAGE_SECRET_KEY")
     secure = get_setting("MINIO_STORAGE_USE_HTTPS", True)
+    region = get_setting("MINIO_STORAGE_REGION", None)
+    if region:
+        kwargs["region"] = region
+
+    if minio_kwargs:
+        kwargs.update(minio_kwargs)
     # Making this client deconstructible allows it to be passed directly as
     # an argument to MinioStorage, since Django needs to be able to
     # deconstruct all Storage constructor arguments for Storages referenced in
@@ -378,7 +384,7 @@ def create_minio_client_from_settings(*, minio_kwargs=None):
         access_key=access_key,
         secret_key=secret_key,
         secure=secure,
-        **minio_kwargs,
+        **kwargs,
     )
     return client
 

--- a/tests/test_app/tests/settings_tests.py
+++ b/tests/test_app/tests/settings_tests.py
@@ -1,0 +1,19 @@
+from django.test import TestCase, override_settings
+
+from minio_storage.storage import MinioMediaStorage
+from tests.test_app.tests.utils import BaseTestMixin
+
+
+class SettingsTests(BaseTestMixin, TestCase):
+    @override_settings(
+        MINIO_STORAGE_REGION="eu-central-666",
+    )
+    def test_settings_with_region(self):
+        ms = MinioMediaStorage()
+        region = ms.client._get_region(self.bucket_name("tests-media"), None)
+        self.assertEqual(region, "eu-central-666")
+
+    def test_settings_without_region(self):
+        ms = MinioMediaStorage()
+        region = ms.client._get_region(self.bucket_name("tests-media"), None)
+        self.assertEqual(region, "us-east-1")


### PR DESCRIPTION
This pull request aims to implement the addition of the `MINIO_STORAGE_REGION` setting, which was discussed in detail in the GitHub issue [here](https://github.com/py-pa/django-minio-storage/issues/129).

To ensure testing, I have created a new TestCase called SettingsTests since I didn't find a good place for the tests. However, I am encountering some failures in the Tox tests on my pull request branch, and I am not entirely familiar with Tox to determine the cause of these failures.