### PR TITLE
Add support for text mode file reading

### DIFF
--- a/minio_storage/files.py
+++ b/minio_storage/files.py
@@ -42,6 +42,21 @@ class MinioStorageFile(File):
         self._mode: str = mode
         self._file = None
 
+    def read(self, *args, **kwargs):
+        if "b" in self._mode:
+            return super().read(*args, **kwargs)
+        else:
+            return super().read(*args, **kwargs).decode()
+
+    def readline(self, *args, **kwargs):
+        if "b" in self._mode:
+            return super().readline(*args, **kwargs)
+        else:
+            return super().readline(*args, **kwargs).decode()
+
+    def readlines(self, *args, **kwargs):
+        return list(self)
+
 
 class ReadOnlyMinioObjectFile(MinioStorageFile, ReadOnlyMixin, NonSeekableMixin):
     """A django File class which directly exposes the underlying minio object. This

--- a/tests/test_app/tests/retrieve_tests.py
+++ b/tests/test_app/tests/retrieve_tests.py
@@ -119,6 +119,16 @@ class RetrieveTestsWithRestrictedBucket(BaseTestMixin, TestCase):
             f = self.media_storage.open("this does not exist")
             f.read()
 
+    def test_reading_respects_binary_mode_flag(self):
+        self.media_storage.save("test.txt", io.BytesIO(b"stuff"))
+        f = self.media_storage.open("test.txt", "rb")
+        self.assertEqual(f.read(), b"stuff")
+
+    def test_reading_respects_text_mode_flag(self):
+        self.media_storage.save("test.txt", io.BytesIO(b"stuff"))
+        f = self.media_storage.open("test.txt", "r")
+        self.assertEqual(f.read(), "stuff")
+
     def test_file_names_are_properly_sanitized(self):
         self.media_storage.save("./meh22222.txt", io.BytesIO(b"stuff"))
 


### PR DESCRIPTION
Prior to this change, `test_reading_respects_text_mode_flag` fails. This PR decodes the bytes on read when the `b` flag is omitted. This is effectively the same implementation as `S3File` from `django-storages`, see https://github.com/jschneier/django-storages/blob/70fa8d96665f0c5e44aacd6c782f6489fa8dc11e/storages/backends/s3.py#L126.