### PR TITLE
Implemented the minio cert check controlling by the "MINIO_CERT_CHECK" setting variable.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,6 +104,9 @@ The following settings are available:
 - `MINIO_STORAGE_STATIC_USE_PRESIGNED`: Determines if the static file URLs
   should be pre-signed (default: `False`) By default set to False.
 
+- `MINIO_STORAGE_CERT_CHECK`:  Ignore SSL certificate verification and avoid SSL VerificationError when using self-generated SSL certificates.  (default: `True`) By default set to True.
+
+
 ## Short Example
 
 ```py

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -115,6 +115,7 @@ class MinioStorage(Storage):
             # request), so don't just use client._region
             region=client._get_region(bucket_name),
             http_client=client._http,
+            cert_check=get_setting("MINIO_CERT_CHECK",True)
         )
 
         return base_url_client

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -368,6 +368,7 @@ def create_minio_client_from_settings(*, minio_kwargs=None):
         "access_key": get_setting("MINIO_STORAGE_ACCESS_KEY"),
         "secret_key": get_setting("MINIO_STORAGE_SECRET_KEY"),
         "secure": get_setting("MINIO_STORAGE_USE_HTTPS", True),
+        "cert_check": get_setting("MINIO_STORAGE_CERT_CHECK",True),
     }
     region = get_setting("MINIO_STORAGE_REGION", None)
     if region:

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -115,7 +115,7 @@ class MinioStorage(Storage):
             # request), so don't just use client._region
             region=client._get_region(bucket_name),
             http_client=client._http,
-            cert_check=get_setting("MINIO_CERT_CHECK",True)
+            cert_check=get_setting("MINIO_STORAGE_CERT_CHECK",True)
         )
 
         return base_url_client


### PR DESCRIPTION
Users can ignore SSL certificate verification and avoid SSL VerificationError when using self-generated SSL certificates by adding the content on the setting.py file of their Django projects. :
```
MINIO_STORAGE_CERT_CHECK=False
```