### PR TITLE
Use Ruff for all linting and formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,176 @@
 /minio_storage/version.py
+
+# Created by https://www.toptal.com/developers/gitignore/api/django
+# Edit at https://www.toptal.com/developers/gitignore?templates=django
+
+### Django ###
+*.log
+*.pot
 *.pyc
-pycache
-htmlcov
-*egg-info
-.coverage
-*.swp
+__pycache__/
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+media
+
+# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
+# in your Git repository. Update and uncomment the following line accordingly.
+# <django-project-name>/staticfiles/
+
+### Django.Python Stack ###
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
 dist/
-.idea/
-env/
-.cache/
-.tox/
+downloads/
+eggs/
 .eggs/
-site/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+
+# Django stuff:
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# End of https://www.toptal.com/developers/gitignore/api/django

--- a/minio_storage/files.py
+++ b/minio_storage/files.py
@@ -37,7 +37,7 @@ class NonSeekableMixin:
 
 class MinioStorageFile(File):
     def __init__(self, name: str, mode: str, storage: "MinioStorage", **kwargs):
-        self._storage: "MinioStorage" = storage
+        self._storage: MinioStorage = storage
         self.name: str = name  # type: ignore[override]
         self._mode: str = mode
         self._file = None

--- a/minio_storage/policy.py
+++ b/minio_storage/policy.py
@@ -11,14 +11,14 @@ class Policy(enum.Enum):
     read_write = "READ_WRITE"
 
     @T.overload
-    def bucket(self, bucket_name: str, *, json_encode: T.Literal[True] = ...) -> str:
-        ...
+    def bucket(
+        self, bucket_name: str, *, json_encode: T.Literal[True] = ...
+    ) -> str: ...
 
     @T.overload
     def bucket(
         self, bucket_name: str, *, json_encode: T.Literal[False]
-    ) -> T.Dict[str, T.Any]:
-        ...
+    ) -> T.Dict[str, T.Any]: ...
 
     def bucket(
         self, bucket_name: str, *, json_encode: bool = True

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -306,12 +306,12 @@ class MinioStorage(Storage):
     @T.overload
     def url(
         self, name: None, *, max_age: T.Optional[datetime.timedelta] = ...
-    ) -> T.NoReturn:
-        ...
+    ) -> T.NoReturn: ...
 
     @T.overload
-    def url(self, name: str, *, max_age: T.Optional[datetime.timedelta] = ...) -> str:
-        ...
+    def url(
+        self, name: str, *, max_age: T.Optional[datetime.timedelta] = ...
+    ) -> str: ...
 
     def url(
         self, name: T.Optional[str], *, max_age: T.Optional[datetime.timedelta] = None
@@ -336,10 +336,9 @@ class MinioStorage(Storage):
             if self.base_url is not None:
                 url = f"{strip_end(self.base_url)}/{quote(strip_beg(name))}"
             else:
-                url = "{}/{}/{}".format(
-                    strip_end(self.endpoint_url),
-                    self.bucket_name,
-                    quote(strip_beg(name)),
+                url = (
+                    f"{strip_end(self.endpoint_url)}/{self.bucket_name}/"
+                    f"{quote(strip_beg(name))}"
                 )
         if url:
             return url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,21 +35,16 @@ Homepage = "https://github.com/py-pa/django-minio-storage"
 Repository = "https://github.com/py-pa/django-minio-storage"
 Documentation = "https://django-minio-storage.readthedocs.io/"
 
-[tool.black]
-target_version = ['py38']
-
 [tool.setuptools_scm]
 write_to =  "minio_storage/version.py"
 write_to_template = '__version__ = "{version}"'
 tag_regex =  "^v(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
-[tool.isort]
-profile = "black"
-skip = [".tox", "migrations", "node_modules", ".git", ".eggs"]
-
 [tool.ruff]
-target-version = 'py38'
+target-version = "py38"
 line-length = 88
+
+[tool.ruff.lint]
 select = [
     "B",
     "C4",
@@ -71,13 +66,3 @@ select = [
     "W",
 ]
 ignore = ["E203"]
-exclude = [
-    "docs",
-    "migrations",
-    ".git",
-    ".ropeproject",
-    ".cache",
-    ".tox",
-    ".eggs",
-    "minio_storage/version.py",
-]

--- a/tox.ini
+++ b/tox.ini
@@ -66,25 +66,20 @@ setenv=
     PYTHONWARNINGS=ignore
 basepython = python3
 deps =
-        ruff==0.0.278
-        black==22.3.0
+    ruff==0.11.8
 commands =
-        ruff check .
-        black --check --diff .
+    ruff check
+    ruff format --check
 
 [testenv:fmt]
 setenv=
     PYTHONWARNINGS=ignore
 basepython = python3
 deps =
-        pyupgrade-directories
-        ruff==0.0.278
-        isort==5.12.0
-        black==23.3.0
+    ruff==0.11.8
 commands =
-        pyup_dirs --exit-zero-even-if-changed --py36-plus minio_storage tests
-        isort .
-        black .
+    ruff check --fix-only
+    ruff format
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
This keeps the exact same set of Ruff rules (although the Ruff version is also bumped), so this PR ensures that the rules are actually getting consistently applied.

It also switches the formatter to Ruff, which is generally Black-compatible, though a few places need to be reformatted for the tests to pass.

Finally, this adds a more comprehensive `.gitignore`, which Ruff will respect when ignoring files.