### PR TITLE
Update supported Python and Django versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     env:
       AWS_ACCESS_KEY_ID: minioadmin

--- a/minio_storage/policy.py
+++ b/minio_storage/policy.py
@@ -18,11 +18,11 @@ class Policy(enum.Enum):
     @T.overload
     def bucket(
         self, bucket_name: str, *, json_encode: T.Literal[False]
-    ) -> T.Dict[str, T.Any]: ...
+    ) -> dict[str, T.Any]: ...
 
     def bucket(
         self, bucket_name: str, *, json_encode: bool = True
-    ) -> T.Union[str, T.Dict[str, T.Any]]:
+    ) -> T.Union[str, dict[str, T.Any]]:
         policies = {
             Policy.get: _get,
             Policy.read: _read,
@@ -36,11 +36,11 @@ class Policy(enum.Enum):
         return pol
 
 
-def _none(bucket_name: str) -> T.Dict[str, T.Any]:
+def _none(bucket_name: str) -> dict[str, T.Any]:
     return {"Version": "2012-10-17", "Statement": []}
 
 
-def _get(bucket_name: str) -> T.Dict[str, T.Any]:
+def _get(bucket_name: str) -> dict[str, T.Any]:
     return {
         "Version": "2012-10-17",
         "Statement": [
@@ -54,7 +54,7 @@ def _get(bucket_name: str) -> T.Dict[str, T.Any]:
     }
 
 
-def _read(bucket_name: str) -> T.Dict[str, T.Any]:
+def _read(bucket_name: str) -> dict[str, T.Any]:
     return {
         "Version": "2012-10-17",
         "Statement": [
@@ -80,7 +80,7 @@ def _read(bucket_name: str) -> T.Dict[str, T.Any]:
     }
 
 
-def _write(bucket_name: str) -> T.Dict[str, T.Any]:
+def _write(bucket_name: str) -> dict[str, T.Any]:
     return {
         "Version": "2012-10-17",
         "Statement": [
@@ -111,7 +111,7 @@ def _write(bucket_name: str) -> T.Dict[str, T.Any]:
     }
 
 
-def _read_write(bucket_name: str) -> T.Dict[str, T.Any]:
+def _read_write(bucket_name: str) -> dict[str, T.Any]:
     return {
         "Version": "2012-10-17",
         "Statement": [

--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -20,7 +20,7 @@ from minio_storage.policy import Policy
 
 logger = getLogger("minio_storage")
 
-ObjectMetadataType = T.Mapping[str, T.Union[str, T.List[str], T.Tuple[str]]]
+ObjectMetadataType = T.Mapping[str, T.Union[str, list[str], tuple[str]]]
 
 
 @deconstructible
@@ -40,7 +40,7 @@ class MinioStorage(Storage):
         bucket_name: str,
         *,
         base_url: T.Optional[str] = None,
-        file_class: T.Optional[T.Type[MinioStorageFile]] = None,
+        file_class: T.Optional[type[MinioStorageFile]] = None,
         auto_create_bucket: bool = False,
         presign_urls: bool = False,
         auto_create_policy: bool = False,
@@ -224,7 +224,7 @@ class MinioStorage(Storage):
             logger.error(error)
         return False
 
-    def listdir(self, path: str) -> T.Tuple[T.List, T.List]:
+    def listdir(self, path: str) -> tuple[list, list]:
         #  [None, "", "."] is supported to mean the configured root among various
         #  implementations of Storage implementations so we copy that behaviour even if
         #  maybe None should raise an exception instead.
@@ -239,8 +239,8 @@ class MinioStorage(Storage):
             if not path.endswith("/"):
                 path += "/"
 
-        dirs: T.List[str] = []
-        files: T.List[str] = []
+        dirs: list[str] = []
+        files: list[str] = []
         try:
             objects = self.client.list_objects(self.bucket_name, prefix=path)
             for o in objects:
@@ -417,7 +417,7 @@ class MinioMediaStorage(MinioStorage):
         minio_client: T.Optional[minio.Minio] = None,
         bucket_name: T.Optional[str] = None,
         base_url: T.Optional[str] = None,
-        file_class: T.Optional[T.Type[MinioStorageFile]] = None,
+        file_class: T.Optional[type[MinioStorageFile]] = None,
         auto_create_bucket: T.Optional[bool] = None,
         presign_urls: T.Optional[bool] = None,
         auto_create_policy: T.Optional[bool] = None,
@@ -495,7 +495,7 @@ class MinioStaticStorage(MinioStorage):
         minio_client: T.Optional[minio.Minio] = None,
         bucket_name: T.Optional[str] = None,
         base_url: T.Optional[str] = None,
-        file_class: T.Optional[T.Type[MinioStorageFile]] = None,
+        file_class: T.Optional[type[MinioStorageFile]] = None,
         auto_create_bucket: T.Optional[bool] = None,
         presign_urls: T.Optional[bool] = None,
         auto_create_policy: T.Optional[bool] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 name = "django-minio-storage"
 description = "Django file storage using the minio python client"
 license = {file = "LICENSE"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-  "django>=3.2",
+  "django>=4.2",
   "minio>=7.1.16",
 ]
 classifiers=[
@@ -41,7 +41,7 @@ write_to_template = '__version__ = "{version}"'
 tag_regex =  "^v(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 88
 
 [tool.ruff.lint]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -13,6 +13,6 @@
   "reportUnboundVariable": "error",
   "reportOptionalMemberAccess": "error",
   "reportOptionalIterable": "error",
-  "pythonVersion": "3.8",
+  "pythonVersion": "3.9",
   "pythonPlatform": "Linux"
 }

--- a/tests/test_app/tests/custom_storage_class_tests.py
+++ b/tests/test_app/tests/custom_storage_class_tests.py
@@ -91,9 +91,10 @@ class CustomStorageTests(BaseTestMixin, TestCase):
             # use the with statement to ensure that both the input stream and output
             # files are closed after the copying is done.
             #
-            with open(filename, "wb") as out_file, storage.open(
-                storage_filename
-            ) as storage_file:
+            with (
+                open(filename, "wb") as out_file,
+                storage.open(storage_filename) as storage_file,
+            ):
                 # Copy the stream from the http stream to the out_file
                 #
                 assert storage_file.file

--- a/tests/test_app/tests/managementcommand_tests.py
+++ b/tests/test_app/tests/managementcommand_tests.py
@@ -1,4 +1,3 @@
-import typing as T
 from io import StringIO
 
 import minio
@@ -87,7 +86,7 @@ class CommandsTests(BaseTestMixin, TestCase):
             lines = out.read().splitlines()
             self.assertEqual(sorted(lines), sorted(expected))
 
-        test_data: T.List[T.Tuple[T.List[str], T.List[str]]] = [
+        test_data: list[tuple[list[str], list[str]]] = [
             (
                 ["-r"],
                 #

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,22 @@
 [tox]
 envlist =
-       {py38,py39,py310,py311}-django42-minioknown
-       py311-django{32,42}-minioknown
-       py311-django42-minio
-       lint
-       docs
-       pyright
+    # All Pythons, oldest Django
+    {py39,py310,py311,py312,py313}-django42-minioknown
+    # Newest Python, all Djangos
+    py313-django{42,51,52}-minioknown
+    # Newest PYthon, newest Django, newest Minio
+    py313-django52-minio
+    lint
+    docs
+    pyright
 
 [gh-actions]
 python =
-       3.8: py38
-       3.9: py39
-       3.10: py310
-       3.11: py311, lint, docs, pyright
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313, lint, docs, pyright
 
 [pytest]
 pythonpath = . tests
@@ -24,47 +28,44 @@ django_find_project = false
 [testenv]
 commands = pytest {posargs}
 setenv =
-        PYTHONDONTWRITEBYTECODE=1
-        MINIO_STORAGE_ENDPOINT={env:MINIO_STORAGE_ENDPOINT:localhost:9153}
-        MINIO_STORAGE_ACCESS_KEY={env:MINIO_STORAGE_ACCESS_KEY:weak_access_key}
-        MINIO_STORAGE_SECRET_KEY={env:MINIO_STORAGE_SECRET_KEY:weak_secret_key}
-        TOX_ENVNAME={envname}
+    PYTHONDONTWRITEBYTECODE=1
+    MINIO_STORAGE_ENDPOINT={env:MINIO_STORAGE_ENDPOINT:localhost:9153}
+    MINIO_STORAGE_ACCESS_KEY={env:MINIO_STORAGE_ACCESS_KEY:weak_access_key}
+    MINIO_STORAGE_SECRET_KEY={env:MINIO_STORAGE_SECRET_KEY:weak_secret_key}
+    TOX_ENVNAME={envname}
 deps =
-        django32: Django==3.2.*
-        django42: Django==4.2.*
-        minio: minio
-        minioknown: minio==7.1.12
-        -rdev-requirements.txt
+    django42: Django==4.2.*
+    django51: Django==5.1.*
+    django52: Django==5.2.*
+    minio: minio
+    minioknown: minio==7.1.12
+    -rdev-requirements.txt
 
-[testenv:py311-django42-minioknown]
+[testenv:py313-django52-minioknown]
 commands = pytest --cov --cov-append --cov-report=term-missing {posargs}
 
 [testenv:coverage-report]
-basepython = python3.11
 deps = coverage[toml]
 skip_install = true
 commands =
     coverage report
     coverage html
-depends=py311-django42-minioknown
+depends=py313-django52-minioknown
 
 [testenv:pyright]
-basepython = python3
 deps =
-        pyright
-        minio
-        django-stubs==4.2.*
-        Django==4.2.*
-        types-requests
-        -rdev-requirements.txt
+    pyright
+    minio
+    django-stubs==4.2.*
+    Django==4.2.*
+    types-requests
+    -rdev-requirements.txt
 commands =
     pyright --level WARNING
-
 
 [testenv:lint]
 setenv=
     PYTHONWARNINGS=ignore
-basepython = python3
 deps =
     ruff==0.11.8
 commands =
@@ -74,7 +75,6 @@ commands =
 [testenv:fmt]
 setenv=
     PYTHONWARNINGS=ignore
-basepython = python3
 deps =
     ruff==0.11.8
 commands =
@@ -82,6 +82,5 @@ commands =
     ruff format
 
 [testenv:docs]
-basepython = python3
 deps = mkdocs
 commands = mkdocs build


### PR DESCRIPTION
Supported Django versions: 4.2, 5.1, 5.2
See: https://endoflife.date/django

Supported Python versions: 3.9, 3.10, 3.11, 3.12, 3.13
Note, Django 4.2 originally supported Python 3.8, but 3.8 is now EOL.
See: https://endoflife.date/python