### PR TITLE
Clarify software license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "django-minio-storage"
 description = "Django file storage using the minio python client"
-license = {file = "LICENSE"}
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE", "LICENSE-APACHE"]
 requires-python = ">=3.9"
 dependencies = [
   "django>=4.2",
@@ -11,7 +12,6 @@ classifiers=[
   "Development Status :: 4 - Beta",
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
@@ -28,7 +28,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 [build-system]
-requires = ["setuptools>=62", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0.3", "setuptools_scm[toml]>=6.2"]
 
 [project.urls]
 Homepage = "https://github.com/py-pa/django-minio-storage"


### PR DESCRIPTION
Update `license` package metadata field, per: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
This requires a newer setuptools to parse.

Remove license classifiers, as they are forbidden by PEP 639.

Fixes #132.