### PR TITLE
Move storage classes to root of module

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,8 +7,8 @@ pip install django-minio-storage
 Add `minio_storage` to `INSTALLED_APPS` in your project settings.
 
 The last step is setting `DEFAULT_FILE_STORAGE` to
-`"minio_storage.storage.MinioMediaStorage"`, and `STATICFILES_STORAGE` to
-`"minio_storage.storage.MinioStaticStorage"`.
+`"minio_storage.MinioMediaStorage"`, and `STATICFILES_STORAGE` to
+`"minio_storage.MinioStaticStorage"`.
 
 ## Django settings Configuration
 
@@ -110,8 +110,8 @@ The following settings are available:
 STATIC_URL = '/static/'
 STATIC_ROOT = './static_files/'
 
-DEFAULT_FILE_STORAGE = "minio_storage.storage.MinioMediaStorage"
-STATICFILES_STORAGE = "minio_storage.storage.MinioStaticStorage"
+DEFAULT_FILE_STORAGE = "minio_storage.MinioMediaStorage"
+STATICFILES_STORAGE = "minio_storage.MinioStaticStorage"
 MINIO_STORAGE_ENDPOINT = 'minio:9000'
 MINIO_STORAGE_ACCESS_KEY = 'KBP6WXGPS387090EZMG8'
 MINIO_STORAGE_SECRET_KEY = 'DRjFXylyfMqn2zilAr33xORhaYz5r9e8r37XPz3A'

--- a/minio_storage/__init__.py
+++ b/minio_storage/__init__.py
@@ -1,0 +1,7 @@
+from storage import MinioMediaStorage, MinioStaticStorage, MinioStorage
+
+__all__ = [
+    "MinioMediaStorage",
+    "MinioStaticStorage",
+    "MinioStorage",
+]

--- a/minio_storage/management/commands/minio.py
+++ b/minio_storage/management/commands/minio.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         group.add_argument(
             "--class",
             type=str,
-            default="minio_storage.storage.MinioMediaStorage",
+            default="minio_storage.MinioMediaStorage",
             help="Storage class to modify "
             "(media/static are short names for default classes)",
         )
@@ -124,9 +124,9 @@ class Command(BaseCommand):
     def storage(self, options):
         class_name: str = options["class"]
         if class_name == "media":
-            class_name = "minio_storage.storage.MinioMediaStorage"
+            class_name = "minio_storage.MinioMediaStorage"
         elif class_name == "static":
-            class_name = "minio_storage.storage.MinioStaticStorage"
+            class_name = "minio_storage.MinioStaticStorage"
 
         try:
             storage_class = import_string(class_name)

--- a/tests/django_minio_storage_tests/settings.py
+++ b/tests/django_minio_storage_tests/settings.py
@@ -30,8 +30,8 @@ DEBUG = True
 ALLOWED_HOSTS = []
 
 
-DEFAULT_STORAGE = "minio_storage.storage.MinioMediaStorage"
-STATICFILES_STORAGE = "minio_storage.storage.MinioStaticStorage"
+DEFAULT_STORAGE = "minio_storage.MinioMediaStorage"
+STATICFILES_STORAGE = "minio_storage.MinioStaticStorage"
 
 MINIO_STORAGE_ENDPOINT = os.getenv("MINIO_STORAGE_ENDPOINT", "minio:9000")
 MINIO_STORAGE_ACCESS_KEY = os.environ["MINIO_STORAGE_ACCESS_KEY"]


### PR DESCRIPTION
Classes can now be imported directly from `minio_storage`, instead of `minio_storage.storage`.

Fixes #85.