### PR TITLE
Allow import of storage classes from the module root

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,8 +7,8 @@ pip install django-minio-storage
 Add `minio_storage` to `INSTALLED_APPS` in your project settings.
 
 The last step is setting `STORAGES['default']['BACKEND']` to
-`'minio_storage.storage.MinioMediaStorage'`, and `STORAGES['staticfiles']['BACKEND']` to
-`'minio_storage.storage.MinioStaticStorage'`.
+`'minio_storage.MinioMediaStorage'`, and `STORAGES['staticfiles']['BACKEND']` to
+`'minio_storage.MinioStaticStorage'`.
 
 ## Django settings Configuration
 
@@ -112,10 +112,10 @@ STATIC_ROOT = './static_files/'
 
 STORAGES = {
     'default': {
-        'BACKEND': 'minio_storage.storage.MinioMediaStorage',
+        'BACKEND': 'minio_storage.MinioMediaStorage',
     },
     'staticfiles': {
-        'BACKEND': 'minio_storage.storage.MinioStaticStorage',
+        'BACKEND': 'minio_storage.MinioStaticStorage',
     },
 }
 MINIO_STORAGE_ENDPOINT = 'minio:9000'

--- a/minio_storage/__init__.py
+++ b/minio_storage/__init__.py
@@ -1,0 +1,7 @@
+from minio_storage.storage import MinioMediaStorage, MinioStaticStorage, MinioStorage
+
+__all__ = [
+    "MinioMediaStorage",
+    "MinioStaticStorage",
+    "MinioStorage",
+]

--- a/minio_storage/management/commands/minio.py
+++ b/minio_storage/management/commands/minio.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         group.add_argument(
             "--class",
             type=str,
-            default="minio_storage.storage.MinioMediaStorage",
+            default="minio_storage.MinioMediaStorage",
             help="Storage class to modify "
             "(media/static are short names for default classes)",
         )
@@ -124,9 +124,9 @@ class Command(BaseCommand):
     def storage(self, options):
         class_name: str = options["class"]
         if class_name == "media":
-            class_name = "minio_storage.storage.MinioMediaStorage"
+            class_name = "minio_storage.MinioMediaStorage"
         elif class_name == "static":
-            class_name = "minio_storage.storage.MinioStaticStorage"
+            class_name = "minio_storage.MinioStaticStorage"
 
         try:
             storage_class = import_string(class_name)

--- a/tests/django_minio_storage_tests/settings.py
+++ b/tests/django_minio_storage_tests/settings.py
@@ -31,10 +31,10 @@ ALLOWED_HOSTS = []
 
 STORAGES = {
     "default": {
-        "BACKEND": "minio_storage.storage.MinioMediaStorage",
+        "BACKEND": "minio_storage.MinioMediaStorage",
     },
     "staticfiles": {
-        "BACKEND": "minio_storage.storage.MinioStaticStorage",
+        "BACKEND": "minio_storage.MinioStaticStorage",
     },
 }
 


### PR DESCRIPTION
Classes can now be imported directly from `minio_storage`, instead of `minio_storage.storage`.

Fixes #85.