### PR TITLE
Rename time information APIs to be Django-compliant

### DIFF
--- a/minio_storage/storage.py
+++ b/minio_storage/storage.py
@@ -348,19 +348,19 @@ class MinioStorage(Storage):
     def endpoint_url(self):
         return self.client._base_url._url.geturl()
 
-    def accessed_time(self, name: str) -> datetime.datetime:
+    def get_accessed_time(self, name: str) -> T.NoReturn:
         """
         Not available via the S3 API
         """
-        return self.modified_time(name)
+        raise NotImplementedError("Accessed time is not supported")
 
-    def created_time(self, name: str) -> datetime.datetime:
+    def get_created_time(self, name: str) -> T.NoReturn:
         """
         Not available via the S3 API
         """
-        return self.modified_time(name)
+        raise NotImplementedError("Created time is not supported")
 
-    def modified_time(self, name: str) -> datetime.datetime:
+    def get_modified_time(self, name: str) -> datetime.datetime:
         try:
             info: Object = self.client.stat_object(self.bucket_name, name)
         except merr.InvalidResponseError as error:

--- a/tests/test_app/tests/retrieve_tests.py
+++ b/tests/test_app/tests/retrieve_tests.py
@@ -45,24 +45,22 @@ class RetrieveTestsWithRestrictedBucket(BaseTestMixin, TestCase):
         with self.assertRaises(S3Error):
             self.media_storage.size(test_file)
 
-    def test_modified_time(self):
+    def test_get_modified_time(self):
         self.assertIsInstance(
-            self.media_storage.modified_time(self.new_file), datetime.datetime
+            self.media_storage.get_modified_time(self.new_file), datetime.datetime
         )
 
-    def test_accessed_time(self):
-        self.assertIsInstance(
-            self.media_storage.accessed_time(self.new_file), datetime.datetime
-        )
+    def test_get_accessed_time(self):
+        with self.assertRaises(NotImplementedError):
+            self.media_storage.get_accessed_time(self.new_file)
 
-    def test_created_time(self):
-        self.assertIsInstance(
-            self.media_storage.created_time(self.new_file), datetime.datetime
-        )
+    def test_get_created_time(self):
+        with self.assertRaises(NotImplementedError):
+            self.media_storage.get_created_time(self.new_file)
 
     def test_modified_time_of_non_existent_raises_exception(self):
         with self.assertRaises(S3Error):
-            self.media_storage.modified_time("nonexistent.jpg")
+            self.media_storage.get_modified_time("nonexistent.jpg")
 
     def _listdir_root(self, root):
         self.media_storage.save("dir1/file2.txt", ContentFile(b"meh"))


### PR DESCRIPTION
This makes `MinioStorage` compliant with the upstream Django `Storage` API. Otherwise, the current behavior is incorrect.

The old method names are kept as deprecated aliases, so this is no longer a breaking change.
