### PR TITLE
Use new STORAGES setting from Django 4.2+

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,9 +6,9 @@ pip install django-minio-storage
 
 Add `minio_storage` to `INSTALLED_APPS` in your project settings.
 
-The last step is setting `DEFAULT_FILE_STORAGE` to
-`"minio_storage.storage.MinioMediaStorage"`, and `STATICFILES_STORAGE` to
-`"minio_storage.storage.MinioStaticStorage"`.
+The last step is setting `STORAGES['default']['BACKEND']` to
+`'minio_storage.storage.MinioMediaStorage'`, and `STORAGES['staticfiles']['BACKEND']` to
+`'minio_storage.storage.MinioStaticStorage'`.
 
 ## Django settings Configuration
 
@@ -18,7 +18,7 @@ The following settings are available:
   `minio.example.org:9000` (note that there is no scheme)).
 
 - `MINIO_STORAGE_ACCESS_KEY` and `MINIO_STORAGE_SECRET_KEY` (mandatory)
-  
+
 - `MINIO_STORAGE_REGION`: Allows you to specify the region. By setting this
   configuration option, an additional HTTP request to Minio for region checking
   can be prevented, resulting in improved performance and reduced latency for
@@ -34,18 +34,18 @@ The following settings are available:
 - `MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET`: whether to create the bucket if it
   does not already exist (default: `False`)
 
-- `MINIO_STORAGE_ASSUME_MEDIA_BUCKET_EXISTS`: whether to ignore media bucket 
-  creation and policy.  
+- `MINIO_STORAGE_ASSUME_MEDIA_BUCKET_EXISTS`: whether to ignore media bucket
+  creation and policy.
   (default: `False`)
 
 - `MINIO_STORAGE_AUTO_CREATE_MEDIA_POLICY`: sets the buckets public policy
   right after it's been created by `MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET`.
   Valid values are: `GET_ONLY`, `READ_ONLY`, `WRITE_ONLY`, `READ_WRITE` and
   `NONE`. (default: `GET_ONLY`)
-  
+
 - `MINIO_STORAGE_MEDIA_OBJECT_METADATA`: set default additional metadata for
   every object persisted during save operations. The value is a dict with
-  string keys and values, example: `{"Cache-Control": "max-age=1000"}`.
+  string keys and values, example: `{'Cache-Control': 'max-age=1000'}`.
   (default: `None`)
 
 - `MINIO_STORAGE_STATIC_BUCKET_NAME`: the bucket that will act as `STATIC`
@@ -55,18 +55,18 @@ The following settings are available:
   does not already exist (default: `False`)
 
 
-- `MINIO_STORAGE_ASSUME_STATIC_BUCKET_EXISTS`: whether to ignore the static bucket 
-  creation and policy.  
+- `MINIO_STORAGE_ASSUME_STATIC_BUCKET_EXISTS`: whether to ignore the static bucket
+  creation and policy.
   (default: `False`)
 
 - `MINIO_STORAGE_AUTO_CREATE_STATIC_POLICY`: sets the buckets public policy
   right after it's been created by `MINIO_STORAGE_AUTO_CREATE_STATIC_BUCKET`.
   Valid values are: `GET_ONLY`, `READ_ONLY`, `WRITE_ONLY`, `READ_WRITE` and
   `NONE`. (default: `GET_ONLY`)
-  
+
 - `MINIO_STORAGE_STATIC_OBJECT_METADATA`: set default additional metadata for
   every object persisted during save operations. The value is a dict with
-  string keys and values, example: `{"Cache-Control": "max-age=1000"}`.
+  string keys and values, example: `{'Cache-Control': 'max-age=1000'}`.
   (default: `None`)
 
 - `MINIO_STORAGE_MEDIA_URL`: the base URL for generating urls to objects from
@@ -110,13 +110,19 @@ The following settings are available:
 STATIC_URL = '/static/'
 STATIC_ROOT = './static_files/'
 
-DEFAULT_FILE_STORAGE = "minio_storage.storage.MinioMediaStorage"
-STATICFILES_STORAGE = "minio_storage.storage.MinioStaticStorage"
+STORAGES = {
+    'default': {
+        'BACKEND': 'minio_storage.storage.MinioMediaStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'minio_storage.storage.MinioStaticStorage',
+    },
+}
 MINIO_STORAGE_ENDPOINT = 'minio:9000'
 MINIO_STORAGE_ACCESS_KEY = 'KBP6WXGPS387090EZMG8'
 MINIO_STORAGE_SECRET_KEY = 'DRjFXylyfMqn2zilAr33xORhaYz5r9e8r37XPz3A'
 MINIO_STORAGE_USE_HTTPS = False
-MINIO_STORAGE_MEDIA_OBJECT_METADATA = {"Cache-Control": "max-age=1000"}
+MINIO_STORAGE_MEDIA_OBJECT_METADATA = {'Cache-Control': 'max-age=1000'}
 MINIO_STORAGE_MEDIA_BUCKET_NAME = 'local-media'
 MINIO_STORAGE_MEDIA_BACKUP_BUCKET = 'Recycle Bin'
 MINIO_STORAGE_MEDIA_BACKUP_FORMAT = '%c/'

--- a/tests/django_minio_storage_tests/settings.py
+++ b/tests/django_minio_storage_tests/settings.py
@@ -29,9 +29,14 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
-DEFAULT_STORAGE = "minio_storage.storage.MinioMediaStorage"
-STATICFILES_STORAGE = "minio_storage.storage.MinioStaticStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "minio_storage.storage.MinioMediaStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "minio_storage.storage.MinioStaticStorage",
+    },
+}
 
 MINIO_STORAGE_ENDPOINT = os.getenv("MINIO_STORAGE_ENDPOINT", "minio:9000")
 MINIO_STORAGE_ACCESS_KEY = os.environ["MINIO_STORAGE_ACCESS_KEY"]
@@ -129,8 +134,6 @@ LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 
 USE_I18N = True
-
-USE_L10N = True
 
 USE_TZ = True
 

--- a/tests/test_app/tests/custom_storage_class_tests.py
+++ b/tests/test_app/tests/custom_storage_class_tests.py
@@ -21,7 +21,7 @@ from .utils import bucket_name as create_test_bucket_name
 @deconstructible
 class PrivateStorage(MinioStorage):
     """The PrivateStorage MinioStorage subclass can be used directly, as a storage in
-    settings.DEFAULT_FILE_STORAGE or after instantiated used individually on any django
+    settings.STORAGES or after instantiated used individually on any django
     FileField:
 
     from django.db import models


### PR DESCRIPTION
This fixes warnings and removes the deprecated (as of Django 4.2, which is the oldest supported version) `DEFAULT_FILE_STORAGE` and `STATICFILES_STORAGE` settings.