### PR TITLE
Use Hatchling for package builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
 [project]
 name = "django-minio-storage"
 description = "Django file storage using the minio python client"
@@ -27,18 +31,23 @@ maintainers = [
 readme = "README.md"
 dynamic = ["version"]
 
-[build-system]
-requires = ["setuptools>=77.0.3", "setuptools_scm[toml]>=6.2"]
-
 [project.urls]
 Homepage = "https://github.com/py-pa/django-minio-storage"
 Repository = "https://github.com/py-pa/django-minio-storage"
 Documentation = "https://django-minio-storage.readthedocs.io/"
 
-[tool.setuptools_scm]
-write_to =  "minio_storage/version.py"
-write_to_template = '__version__ = "{version}"'
-tag_regex =  "^v(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
+[tool.hatch.build]
+packages = [
+  "minio_storage",
+]
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^v(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "minio_storage/version.py"
+template = '__version__ = "{version}"'
 
 [tool.ruff]
 target-version = "py39"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[options]
-packages = find:
-
-
-[options.packages.find]
-include =
-  minio_storage

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
This provides a faster, more modern build backend, which respects `.gitignore` automatically. It retains the `setuptools_scm` functionality for version string injection.

---

Also, this significantly slims down the sdist, such that it now only includes:
```
minio_storage/
LICENSE
LICENSE-APACHE
PKG-INFO
pyproject.toml
README.md
```

Files like `docs/`, `tests/`, `.github`, etc. are now all excluded.

I'd consider this to be an improvement too, since the package is smaller to download and install. Consumers wanting to develop this project can and should just clone the repo.