### PR TITLE
Ensure the package version can always be determined in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     environment: release
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/tests/test_app/tests/package_tests.py
+++ b/tests/test_app/tests/package_tests.py
@@ -1,0 +1,18 @@
+from importlib.metadata import version as package_version
+
+from packaging.version import parse as parse_version
+
+# Any version less than this is a bug, but versions greater are fine
+MIN_VERSION = parse_version("0.5.7")
+
+
+def test_package_version_file():
+    from minio_storage.version import __version__
+
+    version = parse_version(__version__)
+    assert version >= MIN_VERSION
+
+
+def test_package_version_metadata():
+    version = parse_version(package_version("django_minio_storage"))
+    assert version >= MIN_VERSION


### PR DESCRIPTION
This fixes a small bug introduced by #151, where version numbers weren't computed correctly during CI tests.

This also fixes a larger pre-existing bug, where version numbers might not always be computed correctly during CI releases.

Also add a test to prevent future regressions.