### PR TITLE
Support `minio` v7.2.20

### DIFF
--- a/minio_storage/files.py
+++ b/minio_storage/files.py
@@ -85,7 +85,7 @@ class ReadOnlyMinioObjectFile(MinioStorageFile, ReadOnlyMixin, NonSeekableMixin)
         if self._file is None:
             try:
                 obj = self._storage.client.get_object(
-                    self._storage.bucket_name, self.name
+                    bucket_name=self._storage.bucket_name, object_name=self.name
                 )
                 self._file = obj
                 return self._file
@@ -139,7 +139,7 @@ class ReadOnlySpooledTemporaryFile(MinioStorageFile, ReadOnlyMixin):
             obj = None
             try:
                 obj = self._storage.client.get_object(
-                    self._storage.bucket_name, self.name
+                    bucket_name=self._storage.bucket_name, object_name=self.name
                 )
                 self._file = tempfile.SpooledTemporaryFile(
                     max_size=self.max_memory_size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license-files = ["LICENSE", "LICENSE-APACHE"]
 requires-python = ">=3.9"
 dependencies = [
   "django>=4.2",
-  "minio>=7.1.16,<7.2.19",
+  "minio>=7.2.19",
 ]
 classifiers=[
   "Development Status :: 4 - Beta",

--- a/tests/test_app/tests/bucket_tests.py
+++ b/tests/test_app/tests/bucket_tests.py
@@ -78,7 +78,7 @@ class BucketPolicyTests(BaseTestMixin, TestCase):
     def test_auto_create_no_policy(self):
         ms = MinioMediaStorage()
         with self.assertRaises(minio.error.S3Error):
-            ms.client.get_bucket_policy(ms.bucket_name)
+            ms.client.get_bucket_policy(bucket_name=ms.bucket_name)
 
     @override_settings(
         MINIO_STORAGE_AUTO_CREATE_MEDIA_POLICY=True,
@@ -89,7 +89,7 @@ class BucketPolicyTests(BaseTestMixin, TestCase):
         self.maxDiff = 50000
         self.assertPolicyEqual(
             Policy.get.bucket(ms.bucket_name, json_encode=False),
-            json.loads(ms.client.get_bucket_policy(ms.bucket_name)),
+            json.loads(ms.client.get_bucket_policy(bucket_name=ms.bucket_name)),
         )
         fn = ms.save("somefile", ContentFile(b"test"))
         self.assertEqual(ms.open(fn).read(), b"test")
@@ -108,7 +108,7 @@ class BucketPolicyTests(BaseTestMixin, TestCase):
         self.maxDiff = 50000
         self.assertPolicyEqual(
             Policy.get.bucket(ms.bucket_name, json_encode=False),
-            json.loads(ms.client.get_bucket_policy(ms.bucket_name)),
+            json.loads(ms.client.get_bucket_policy(bucket_name=ms.bucket_name)),
         )
         fn = ms.save("somefile", ContentFile(b"test"))
         self.assertEqual(ms.open(fn).read(), b"test")
@@ -126,7 +126,7 @@ class BucketPolicyTests(BaseTestMixin, TestCase):
         self.maxDiff = 50000
         self.assertPolicyEqual(
             Policy.write.bucket(ms.bucket_name, json_encode=False),
-            json.loads(ms.client.get_bucket_policy(ms.bucket_name)),
+            json.loads(ms.client.get_bucket_policy(bucket_name=ms.bucket_name)),
         )
         fn = ms.save("somefile", ContentFile(b"test"))
         self.assertEqual(ms.open(fn).read(), b"test")
@@ -144,7 +144,7 @@ class BucketPolicyTests(BaseTestMixin, TestCase):
         self.maxDiff = 50000
         self.assertPolicyEqual(
             Policy.read_write.bucket(ms.bucket_name, json_encode=False),
-            json.loads(ms.client.get_bucket_policy(ms.bucket_name)),
+            json.loads(ms.client.get_bucket_policy(bucket_name=ms.bucket_name)),
         )
 
     @override_settings(

--- a/tests/test_app/tests/custom_storage_class_tests.py
+++ b/tests/test_app/tests/custom_storage_class_tests.py
@@ -43,10 +43,10 @@ class PrivateStorage(MinioStorage):
 
     def __init__(self, bucket_name=None):
         # we can create the minio client ourselves or use
-        # create_minio_client_from_settings convinience function while providing it with
+        # create_minio_client_from_settings convenience function while providing it with
         # extra args.
         #
-        client = create_minio_client_from_settings(minio_kwargs={"region": "us-east-1"})
+        client = create_minio_client_from_settings(region="us-east-1")
 
         # or use our own Django setting
         #
@@ -128,4 +128,4 @@ class CustomStorageTests(BaseTestMixin, TestCase):
         #
         # use the minio client directly to also remove bucket
         #
-        storage.client.remove_bucket(storage.bucket_name)
+        storage.client.remove_bucket(bucket_name=storage.bucket_name)

--- a/tests/test_app/tests/settings_tests.py
+++ b/tests/test_app/tests/settings_tests.py
@@ -10,10 +10,10 @@ class SettingsTests(BaseTestMixin, TestCase):
     )
     def test_settings_with_region(self):
         ms = MinioMediaStorage()
-        region = ms.client._get_region(self.bucket_name("tests-media"))
+        region = ms.client._get_region(bucket_name=self.bucket_name("tests-media"))
         self.assertEqual(region, "eu-central-666")
 
     def test_settings_without_region(self):
         ms = MinioMediaStorage()
-        region = ms.client._get_region(self.bucket_name("tests-media"))
+        region = ms.client._get_region(bucket_name=self.bucket_name("tests-media"))
         self.assertEqual(region, "us-east-1")

--- a/tests/test_app/tests/upload_tests.py
+++ b/tests/test_app/tests/upload_tests.py
@@ -77,7 +77,7 @@ class UploadTests(BaseTestMixin, TestCase):
     def test_metadata(self):
         ivan = self.media_storage.save("pelican.txt", ContentFile(b"Ivan le Pelican"))
         res = self.media_storage.client.stat_object(
-            self.media_storage.bucket_name, ivan
+            bucket_name=self.media_storage.bucket_name, object_name=ivan
         )
         metadata_attrs = {
             "Accept-Ranges",
@@ -102,7 +102,7 @@ class TestDefaultObjectMetadata(BaseTestMixin, TestCase):
     def test_default_metadata(self):
         ivan = self.media_storage.save("pelican.txt", ContentFile(b"Ivan le Pelican"))
         res = self.media_storage.client.stat_object(
-            self.media_storage.bucket_name, ivan
+            bucket_name=self.media_storage.bucket_name, object_name=ivan
         )
 
         assert res.metadata is not None

--- a/tests/test_app/tests/utils.py
+++ b/tests/test_app/tests/utils.py
@@ -51,7 +51,7 @@ class BaseTestMixin:
         if client is None:
             client = self.minio_client()
 
-        for obj in client.list_objects(name, "", True):
+        for obj in client.list_objects(bucket_name=name, recursive=True):
             assert obj.object_name is not None
-            client.remove_object(name, obj.object_name)
-        client.remove_bucket(name)
+            client.remove_object(bucket_name=name, object_name=obj.object_name)
+        client.remove_bucket(bucket_name=name)

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     django51: Django==5.1.*
     django52: Django==5.2.*
     minio: minio
-    minioknown: minio==7.1.12
+    minioknown: minio==7.2.19
     -rdev-requirements.txt
 commands =
     pytest {posargs}


### PR DESCRIPTION
Supersedes the `<7.2.19` cap added in #161, which also excluded v7.2.20.

## What happened upstream

v7.2.19 made every `Minio` method and the constructor keyword-only, added `region` / `extra_headers` / `extra_query_params` throughout, and renamed `put_object`'s `metadata` argument to `user_metadata`, retyping it from a plain mapping to a `urllib3.HTTPHeaderDict`.

v7.2.20 reverts all of it. It was cut from v7.2.18 with those changes dropped, and its changelog runs [7.2.18...7.2.20](https://github.com/minio/minio-py/compare/7.2.18...7.2.20), skipping v7.2.19 entirely. Diffing the argument structure of every public method in the two releases' wheels gives zero differences: the APIs are identical.

The keyword-only design now targets v8.0.0 ([minio/minio-py#1530](https://github.com/minio/minio-py/pull/1530)), which is unreleased. v7.2.20 has been the latest release on PyPI since 2025-11-27.

So v7.2.19 is a single bad release rather than a new baseline, and the right constraint is to exclude that one version instead of capping below it.

## Changes

- `minio>=7.1.16,<7.2.19` becomes `minio>=7.1.16,!=7.2.19`.
- All `Minio` arguments are now passed by keyword. This is not required by any currently supported version, but it works on all of them and is forward-compatible with v8.0.0.
- The `minioknown` Tox factor is pinned to 7.1.16, the floor of the supported range. It was pinned to 7.1.12, below the floor, so CI was exercising a version the package never claimed to support.
- `Command.policy_get` re-raises an `S3Error` that matches neither `NoSuchBucket` nor `NoSuchBucketPolicy`. It previously swallowed the error and returned `None`.
- Type annotations on the `minio` management command.

No public API of this package changes.

## Testing

The full suite passes against minio 7.1.16 (the floor), 7.2.18, and 7.2.20 (the latest). Every call site was additionally checked against 7.1.16, 7.2.0, 7.2.15, 7.2.16, 7.2.17, 7.2.18, 7.2.19 and 7.2.20 by binding it to each release's signatures; the only failure across that range is on v7.2.19, which this PR excludes.

`ruff check`, `ruff format --check`, and `pyright --level WARNING` are clean, the latter against v7.2.20.
