### PR TITLE
Pin minio client to <7.2.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license-files = ["LICENSE", "LICENSE-APACHE"]
 requires-python = ">=3.9"
 dependencies = [
   "django>=4.2",
-  "minio>=7.1.16",
+  "minio>=7.1.16,<7.2.19",
 ]
 classifiers=[
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
v7.2.19 has a lot of breaking changes. Pin to earlier versions until we can resolve the issues.